### PR TITLE
Fix xlsx2json conversion to use first row as attribute names

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,10 +68,18 @@ function convertXlsxToJson(filePath) {
         .then(() => {
             const worksheet = workbook.getWorksheet(1);
             const json = [];
+            let headers = [];
             worksheet.eachRow({ includeEmpty: true }, function(row, rowNumber) {
-                const rowValue = row.values;
-                rowValue.shift(); // Remove the first element which is undefined due to ExcelJS indexing
-                json.push(rowValue);
+                if (rowNumber === 1) {
+                    headers = row.values;
+                    headers.shift(); // Remove the first element which is undefined due to ExcelJS indexing
+                } else {
+                    const rowData = {};
+                    row.values.forEach((value, index) => {
+                        rowData[headers[index - 1]] = value; // Map each row's values to the headers
+                    });
+                    json.push(rowData);
+                }
             });
             return json;
         });


### PR DESCRIPTION
Related to #3

Implements the correct handling of the first row as attribute names in the `convertXlsxToJson` function for the xlsx2json conversion process.

- **Adjusts JSON conversion logic**: Modifies the `convertXlsxToJson` function to treat the first row of the Excel sheet as headers. This row is used to map each subsequent row's values to these headers, creating a JSON object for each row.
- **Enhances data mapping**: Introduces a headers array to store the first row values. Each row's values are then mapped to these headers, ensuring that the JSON output correctly reflects the structure where the first row serves as attribute names.
- **Preserves original functionality**: Maintains all other functionalities of the `doConvert` function, including the json2xlsx conversion process and the handling of file paths and arguments.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/sunzsh/jsonfile2xlsx/issues/3?shareId=d84b5565-d5ff-44c0-b4cc-c13bb4ddd044).